### PR TITLE
Add alpha channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ If the default colors don't fit your project, you can always change them.
 | hideHEX  | `bool`       | false   | Hide HEX input.                                                          |
 | hideRGB  | `bool`       | false   | Hide RGB input.                                                          |
 | hideHSV  | `bool`       | false   | Hide HSV input.                                                          |
+| alpha    | `bool`       | false   | Enable alpha channel.                                                    |
 | dark     | `bool`       | false   | Color theme.                                                             |
 
 [1]: #color
@@ -148,19 +149,21 @@ If the default colors don't fit your project, you can always change them.
 
 ### `ColorRGB`
 
-| Field | Type     |
-| ----- | -------- |
-| r     | `number` |
-| g     | `number` |
-| b     | `number` |
+| Field | Type                    |
+| ----- | ----------------------- |
+| r     | `number`                |
+| g     | `number`                |
+| b     | `number`                |
+| a     | `number` \| `undefined` |
 
 ### `ColorHSV`
 
-| Field | Type     |
-| ----- | -------- |
-| h     | `number` |
-| s     | `number` |
-| v     | `number` |
+| Field | Type                    |
+| ----- | ----------------------- |
+| h     | `number`                |
+| s     | `number`                |
+| v     | `number`                |
+| a     | `number` \| `undefined` |
 
 <hr />
 

--- a/src/components/Alpha.component.tsx
+++ b/src/components/Alpha.component.tsx
@@ -6,20 +6,37 @@ import { Interactive } from "./Interactive.component";
 
 export const Alpha = ({ width, color, onChange }: AlphaProps): JSX.Element => {
   const position = useMemo(() => {
-    const x = getAlphaCoordinates(color.hsv.a ?? 100, width);
+    const x = getAlphaCoordinates(color.hsv.a ?? 1, width);
 
     return x;
   }, [color.hsv.a, width]);
 
   const updateColor = (x: number): void => {
-    onChange(toColor("hsv", { ...color.hsv, a: (x / width) * 100 }));
+    onChange(toColor("hsv", { ...color.hsv, a: x / width }));
   };
 
   return (
-    <Interactive className="rcp-alpha" onChange={updateColor}>
+    <Interactive
+      className="rcp-alpha"
+      onChange={updateColor}
+      style={{
+        background: `linear-gradient(to right, rgba(${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}, 0), rgba(${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}, 1)) top left / auto auto,
+                conic-gradient(#666 0.25turn, #999 0.25turn 0.5turn, #666 0.5turn 0.75turn, #999 0.75turn) top left / 12px 12px
+                repeat`,
+      }}
+    >
       <div
         className="rcp-alpha-cursor"
-        style={{ left: position, backgroundColor: `hsl(0, 0%, ${color.hsv.a ?? 100}%)` }}
+        style={{
+          left: position,
+          background: `linear-gradient(to right, rgba(${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}, ${
+            color.rgb.a ?? 1
+          }), rgba(${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}, ${color.rgb.a ?? 1})) top left / auto auto,
+                conic-gradient(#666 0.25turn, #999 0.25turn 0.5turn, #666 0.5turn 0.75turn, #999 0.75turn) ${
+                  -position - 2
+                }px 2px / 12px 12px
+                repeat`,
+        }}
       />
     </Interactive>
   );

--- a/src/components/Alpha.component.tsx
+++ b/src/components/Alpha.component.tsx
@@ -1,0 +1,26 @@
+import React, { useMemo } from "react";
+import { AlphaProps } from "../interfaces/Alpha.interface";
+import { getAlphaCoordinates } from "../utils/coordinates.util";
+import { toColor } from "../utils/toColor.util";
+import { Interactive } from "./Interactive.component";
+
+export const Alpha = ({ width, color, onChange }: AlphaProps): JSX.Element => {
+  const position = useMemo(() => {
+    const x = getAlphaCoordinates(color.hsv.a ?? 100, width);
+
+    return x;
+  }, [color.hsv.a, width]);
+
+  const updateColor = (x: number): void => {
+    onChange(toColor("hsv", { ...color.hsv, a: (x / width) * 100 }));
+  };
+
+  return (
+    <Interactive className="rcp-alpha" onChange={updateColor}>
+      <div
+        className="rcp-alpha-cursor"
+        style={{ left: position, backgroundColor: `hsl(0, 0%, ${color.hsv.a ?? 100}%)` }}
+      />
+    </Interactive>
+  );
+};

--- a/src/components/ColorPicker.component.tsx
+++ b/src/components/ColorPicker.component.tsx
@@ -20,7 +20,7 @@ export const ColorPicker = ({
     <Saturation width={width} height={height} color={color} onChange={onChange} />
     <div className="rcp-body">
       <Hue width={width - 40} color={color} onChange={onChange} />
-      {alpha ? <Alpha width={width - 40} color={color} onChange={onChange} /> : null}
+      {alpha && <Alpha width={width - 40} color={color} onChange={onChange} />}
       <Fields color={color} hideHEX={hideHEX} hideRGB={hideRGB} hideHSV={hideHSV} alpha={alpha} onChange={onChange} />
     </div>
   </div>

--- a/src/components/ColorPicker.component.tsx
+++ b/src/components/ColorPicker.component.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ColorPickerProps } from "../interfaces/ColorPicker.interface";
+import { Alpha } from "./Alpha.component";
 import { Saturation } from "./Saturation.component";
 import { Hue } from "./Hue.component";
 import { Fields } from "./Fields.component";
@@ -12,13 +13,15 @@ export const ColorPicker = ({
   hideHEX = false,
   hideRGB = false,
   hideHSV = false,
+  alpha = false,
   dark = false,
 }: ColorPickerProps): JSX.Element => (
   <div className={`rcp ${dark ? "rcp-dark" : "rcp-light"}`} style={{ width }}>
     <Saturation width={width} height={height} color={color} onChange={onChange} />
     <div className="rcp-body">
       <Hue width={width - 40} color={color} onChange={onChange} />
-      <Fields color={color} hideHEX={hideHEX} hideRGB={hideRGB} hideHSV={hideHSV} onChange={onChange} />
+      {alpha ? <Alpha width={width - 40} color={color} onChange={onChange} /> : null}
+      <Fields color={color} hideHEX={hideHEX} hideRGB={hideRGB} hideHSV={hideHSV} alpha={alpha} onChange={onChange} />
     </div>
   </div>
 );

--- a/src/components/Fields.component.tsx
+++ b/src/components/Fields.component.tsx
@@ -42,17 +42,28 @@ const UpperFloor = ({ color, hideHEX, onChange }: UpperFloorProps): JSX.Element 
   );
 };
 
-const LowerFloor = ({ color, hideRGB, hideHSV, onChange }: LowerFloorProps): JSX.Element => {
+const LowerFloor = ({ color, hideRGB, hideHSV, alpha, onChange }: LowerFloorProps): JSX.Element => {
   const getValueRGB = useCallback(
-    () => ({ value: `${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}`, inputted: false }),
-    [color.rgb]
+    () => ({
+      value:
+        alpha && color.rgb.a !== undefined
+          ? `${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}, ${color.rgb.a}`
+          : `${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}`,
+      inputted: false,
+    }),
+    [color.rgb, alpha]
   );
   const getValueHSV = useCallback(
     () => ({
-      value: `${Math.round(color.hsv.h)}°, ${Math.round(color.hsv.s)}%, ${Math.round(color.hsv.v)}%`,
+      value:
+        alpha && color.hsv.a !== undefined
+          ? `${Math.round(color.hsv.h)}°, ${Math.round(color.hsv.s)}%, ${Math.round(color.hsv.v)}%, ${Math.round(
+              color.hsv.a
+            )}%`
+          : `${Math.round(color.hsv.h)}°, ${Math.round(color.hsv.s)}%, ${Math.round(color.hsv.v)}%`,
       inputted: false,
     }),
-    [color.hsv]
+    [color.hsv, alpha]
   );
 
   const [valueRGB, setValueRGB] = useState(getValueRGB);
@@ -79,6 +90,12 @@ const LowerFloor = ({ color, hideRGB, hideHSV, onChange }: LowerFloorProps): JSX
       onChange(toColor("rgb", rgb));
     }
 
+    if (alpha && value && value.length === 4) {
+      const rgb = toRgb(value.slice(0, 4));
+
+      onChange(toColor("rgb", rgb));
+    }
+
     setValueRGB({ ...valueRGB, value: e.target.value });
   };
 
@@ -87,6 +104,12 @@ const LowerFloor = ({ color, hideRGB, hideHSV, onChange }: LowerFloorProps): JSX
 
     if (value && value.length === 3) {
       const hsb = toHsv(value.slice(0, 3));
+
+      onChange(toColor("hsv", hsb));
+    }
+
+    if (alpha && value && value.length === 4) {
+      const hsb = toHsv(value.slice(0, 4));
 
       onChange(toColor("hsv", hsb));
     }
@@ -128,12 +151,12 @@ const LowerFloor = ({ color, hideRGB, hideHSV, onChange }: LowerFloorProps): JSX
   );
 };
 
-export const Fields = ({ color, hideHEX, hideRGB, hideHSV, onChange }: FieldsProps): JSX.Element => {
+export const Fields = ({ color, hideHEX, hideRGB, hideHSV, alpha, onChange }: FieldsProps): JSX.Element => {
   return (
     <>
       {(!hideHEX || !hideRGB || !hideHSV) && (
         <div className="rcp-fields">
-          <LowerFloor color={color} hideRGB={hideRGB} hideHSV={hideHSV} onChange={onChange} />
+          <LowerFloor color={color} hideRGB={hideRGB} hideHSV={hideHSV} alpha={alpha} onChange={onChange} />
           <UpperFloor color={color} hideHEX={hideHEX} onChange={onChange} />
         </div>
       )}

--- a/src/components/Fields.component.tsx
+++ b/src/components/Fields.component.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState, useEffect } from "react";
 import { UpperFloorProps, LowerFloorProps, FieldsProps } from "../interfaces/Fields.interface";
 import { toHsv, toRgb } from "../utils/convert.util";
+import { roundFloat } from "../utils/roundFloat.util";
 import { toColor } from "../utils/toColor.util";
 import { validHex } from "../utils/validate.util";
 
@@ -45,22 +46,18 @@ const UpperFloor = ({ color, hideHEX, onChange }: UpperFloorProps): JSX.Element 
 const LowerFloor = ({ color, hideRGB, hideHSV, alpha, onChange }: LowerFloorProps): JSX.Element => {
   const getValueRGB = useCallback(
     () => ({
-      value:
-        alpha && color.rgb.a !== undefined
-          ? `${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}, ${color.rgb.a}`
-          : `${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}`,
+      value: `${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b}${
+        alpha && color.rgb.a !== undefined ? `, ${roundFloat(color.rgb.a, 3)}` : ""
+      }`,
       inputted: false,
     }),
     [color.rgb, alpha]
   );
   const getValueHSV = useCallback(
     () => ({
-      value:
-        alpha && color.hsv.a !== undefined
-          ? `${Math.round(color.hsv.h)}°, ${Math.round(color.hsv.s)}%, ${Math.round(color.hsv.v)}%, ${Math.round(
-              color.hsv.a
-            )}%`
-          : `${Math.round(color.hsv.h)}°, ${Math.round(color.hsv.s)}%, ${Math.round(color.hsv.v)}%`,
+      value: `${Math.round(color.hsv.h)}°, ${Math.round(color.hsv.s)}%, ${Math.round(color.hsv.v)}%${
+        alpha && color.hsv.a !== undefined ? `, ${roundFloat(color.hsv.a, 3)}` : ""
+      }`,
       inputted: false,
     }),
     [color.hsv, alpha]
@@ -82,16 +79,10 @@ const LowerFloor = ({ color, hideRGB, hideHSV, alpha, onChange }: LowerFloorProp
   }, [valueHSV.inputted, getValueHSV]);
 
   const changeRGB = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value.match(/\d+/g);
+    const value = e.target.value.match(/\d+(?:\.\d+)?/g);
 
-    if (value && value.length === 3) {
-      const rgb = toRgb(value.slice(0, 3));
-
-      onChange(toColor("rgb", rgb));
-    }
-
-    if (alpha && value && value.length === 4) {
-      const rgb = toRgb(value.slice(0, 4));
+    if (value && (value.length === 3 || (alpha && value.length === 4))) {
+      const rgb = toRgb(value);
 
       onChange(toColor("rgb", rgb));
     }
@@ -100,16 +91,10 @@ const LowerFloor = ({ color, hideRGB, hideHSV, alpha, onChange }: LowerFloorProp
   };
 
   const changeHSB = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value.match(/\d+/g);
+    const value = e.target.value.match(/\d+(?:\.\d+)?/g);
 
-    if (value && value.length === 3) {
-      const hsb = toHsv(value.slice(0, 3));
-
-      onChange(toColor("hsv", hsb));
-    }
-
-    if (alpha && value && value.length === 4) {
-      const hsb = toHsv(value.slice(0, 4));
+    if (value && (value.length === 3 || (alpha && value.length === 4))) {
+      const hsb = toHsv(value);
 
       onChange(toColor("hsv", hsb));
     }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -98,9 +98,6 @@
   width: 100%;
   height: 12px;
 
-  background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1)) top left / auto auto,
-    conic-gradient(#666 0.25turn, #999 0.25turn 0.5turn, #555 0.5turn 0.75turn, #999 0.75turn) top left / 12px 12px
-      repeat;
   border-radius: 10px;
 
   user-select: none;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -92,6 +92,34 @@
   transform: translate(-10px, -4px);
 }
 
+.rcp-alpha {
+  position: relative;
+
+  width: 100%;
+  height: 12px;
+
+  background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1)) top left / auto auto,
+    conic-gradient(#666 0.25turn, #999 0.25turn 0.5turn, #555 0.5turn 0.75turn, #999 0.75turn) top left / 12px 12px
+      repeat;
+  border-radius: 10px;
+
+  user-select: none;
+}
+
+.rcp-alpha-cursor {
+  position: absolute;
+
+  width: 20px;
+  height: 20px;
+
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 0px 0px 0.5px;
+  box-sizing: border-box;
+
+  transform: translate(-10px, -4px);
+}
+
 .rcp-fields {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/src/hooks/useColor.hook.ts
+++ b/src/hooks/useColor.hook.ts
@@ -5,7 +5,7 @@ import { toColor } from "../utils/toColor.util";
 /**
  * Returns a stateful [Color](https://github.com/Wondermarin/react-color-palette#color), and a function to update it.
  * @param model HEX.
- * @param initColor Color in HEX model (3-6 digit) or [HTML Color Names](https://www.w3.org/wiki/CSS/Properties/color/keywords).
+ * @param initColor Color in HEX model (3-6 digit or 4-8 digit with alpha) or [HTML Color Names](https://www.w3.org/wiki/CSS/Properties/color/keywords).
  */
 export function useColor(model: "hex", initColor: Color["hex"]): [Color, React.Dispatch<React.SetStateAction<Color>>];
 /**

--- a/src/interfaces/Alpha.interface.ts
+++ b/src/interfaces/Alpha.interface.ts
@@ -1,0 +1,7 @@
+import { Color } from "./Color.interface";
+
+export interface AlphaProps {
+  readonly width: number;
+  readonly color: Color;
+  readonly onChange: React.Dispatch<React.SetStateAction<Color>>;
+}

--- a/src/interfaces/Color.interface.ts
+++ b/src/interfaces/Color.interface.ts
@@ -8,10 +8,12 @@ interface ColorRGB {
   readonly r: number;
   readonly g: number;
   readonly b: number;
+  readonly a?: number;
 }
 
 interface ColorHSV {
   readonly h: number;
   readonly s: number;
   readonly v: number;
+  readonly a?: number;
 }

--- a/src/interfaces/ColorPicker.interface.ts
+++ b/src/interfaces/ColorPicker.interface.ts
@@ -30,6 +30,10 @@ export interface ColorPickerProps {
    */
   readonly hideHSV?: boolean;
   /**
+   * Enable alpha channel.
+   */
+  readonly alpha?: boolean;
+  /**
    * Color theme.
    */
   readonly dark?: boolean;

--- a/src/interfaces/Fields.interface.ts
+++ b/src/interfaces/Fields.interface.ts
@@ -10,6 +10,7 @@ export interface LowerFloorProps {
   readonly color: Color;
   readonly hideRGB: boolean;
   readonly hideHSV: boolean;
+  readonly alpha: boolean;
   readonly onChange: React.Dispatch<React.SetStateAction<Color>>;
 }
 
@@ -18,5 +19,6 @@ export interface FieldsProps {
   readonly hideHEX: boolean;
   readonly hideRGB: boolean;
   readonly hideHSV: boolean;
+  readonly alpha: boolean;
   readonly onChange: React.Dispatch<React.SetStateAction<Color>>;
 }

--- a/src/utils/convert.util.ts
+++ b/src/utils/convert.util.ts
@@ -13,13 +13,12 @@ export function toHex(value: string): Color["hex"] {
 
     return ctx.fillStyle;
   } else if (value.length === 4 || value.length === 5) {
-    let newValue = "#";
+    value = value
+      .split("")
+      .map((v, i) => (i === 0 ? "#" : v + v))
+      .join("");
 
-    for (let i = 1; i < value.length; i++) {
-      newValue += value[i] + value[i];
-    }
-
-    return newValue;
+    return value;
   } else if (value.length === 7 || value.length === 9) {
     return value;
   }
@@ -28,13 +27,13 @@ export function toHex(value: string): Color["hex"] {
 }
 
 export function toRgb(value: string[]): Color["rgb"] {
-  const [r, g, b, a] = value.map((v) => clamp(Number(v), 255, 0));
+  const [r, g, b, a] = value.map((v, i) => (i < 3 ? clamp(Number(v), 255, 0) : clamp(Number(v), 1, 0)));
 
   return { r, g, b, a };
 }
 
 export function toHsv(value: string[]): Color["hsv"] {
-  const [h, s, v, a] = value.map((v, i) => clamp(Number(v), i ? 100 : 360, 0));
+  const [h, s, v, a] = value.map((v, i) => clamp(Number(v), i === 0 ? 360 : i < 3 ? 100 : 1, 0));
 
   return { h, s, v, a };
 }
@@ -47,21 +46,13 @@ export function hex2rgb(hex: Color["hex"]): Color["rgb"] {
   const b = parseInt(hex.slice(4, 6), 16);
   const a = parseInt(hex.slice(6, 8), 16);
 
-  if (!Number.isNaN(a)) {
-    return { r, g, b, a };
-  }
-
-  return { r, g, b };
+  return { r, g, b, a: Number.isNaN(a) ? undefined : a / 255 };
 }
 
 export function rgb2hsv({ r, g, b, a }: Color["rgb"]): Color["hsv"] {
   r /= 255;
   g /= 255;
   b /= 255;
-  if (a !== undefined) {
-    a /= 255;
-    a *= 100;
-  }
 
   const max = Math.max(r, g, b);
   const d = max - Math.min(r, g, b);
@@ -76,9 +67,6 @@ export function rgb2hsv({ r, g, b, a }: Color["rgb"]): Color["hsv"] {
 export function hsv2rgb({ h, s, v, a }: Color["hsv"]): Color["rgb"] {
   s /= 100;
   v /= 100;
-  if (a !== undefined) {
-    a = Math.round((a / 100) * 255);
-  }
 
   const i = ~~(h / 60);
   const f = h / 60 - i;
@@ -95,7 +83,9 @@ export function hsv2rgb({ h, s, v, a }: Color["hsv"]): Color["rgb"] {
 }
 
 export function rgb2hex({ r, g, b, a }: Color["rgb"]): Color["hex"] {
-  const hex = [r, g, b, a].map((v) => (v !== undefined ? v.toString(16).padStart(2, "0") : "")).join("");
+  const hex = [r, g, b, a]
+    .map((v, i) => (v !== undefined ? (i < 3 ? v : Math.round(v * 255)).toString(16).padStart(2, "0") : ""))
+    .join("");
 
   return `#${hex}`;
 }

--- a/src/utils/convert.util.ts
+++ b/src/utils/convert.util.ts
@@ -2,7 +2,7 @@ import { Color } from "../interfaces/Color.interface";
 import { clamp } from "./clamp.util";
 
 export function toHex(value: string): Color["hex"] {
-  if (!value.startsWith("#") || value.length === 4) {
+  if (!value.startsWith("#")) {
     const ctx = document.createElement("canvas").getContext("2d");
 
     if (!ctx) {
@@ -12,7 +12,15 @@ export function toHex(value: string): Color["hex"] {
     ctx.fillStyle = value;
 
     return ctx.fillStyle;
-  } else if (value.length === 7) {
+  } else if (value.length === 4 || value.length === 5) {
+    let newValue = "#";
+
+    for (let i = 1; i < value.length; i++) {
+      newValue += value[i] + value[i];
+    }
+
+    return newValue;
+  } else if (value.length === 7 || value.length === 9) {
     return value;
   }
 
@@ -20,15 +28,15 @@ export function toHex(value: string): Color["hex"] {
 }
 
 export function toRgb(value: string[]): Color["rgb"] {
-  const [r, g, b] = value.map((v) => clamp(Number(v), 255, 0));
+  const [r, g, b, a] = value.map((v) => clamp(Number(v), 255, 0));
 
-  return { r, g, b };
+  return { r, g, b, a };
 }
 
 export function toHsv(value: string[]): Color["hsv"] {
-  const [h, s, v] = value.map((v, i) => clamp(Number(v), i ? 100 : 360, 0));
+  const [h, s, v, a] = value.map((v, i) => clamp(Number(v), i ? 100 : 360, 0));
 
-  return { h, s, v };
+  return { h, s, v, a };
 }
 
 export function hex2rgb(hex: Color["hex"]): Color["rgb"] {
@@ -37,14 +45,23 @@ export function hex2rgb(hex: Color["hex"]): Color["rgb"] {
   const r = parseInt(hex.slice(0, 2), 16);
   const g = parseInt(hex.slice(2, 4), 16);
   const b = parseInt(hex.slice(4, 6), 16);
+  const a = parseInt(hex.slice(6, 8), 16);
+
+  if (!Number.isNaN(a)) {
+    return { r, g, b, a };
+  }
 
   return { r, g, b };
 }
 
-export function rgb2hsv({ r, g, b }: Color["rgb"]): Color["hsv"] {
+export function rgb2hsv({ r, g, b, a }: Color["rgb"]): Color["hsv"] {
   r /= 255;
   g /= 255;
   b /= 255;
+  if (a !== undefined) {
+    a /= 255;
+    a *= 100;
+  }
 
   const max = Math.max(r, g, b);
   const d = max - Math.min(r, g, b);
@@ -53,12 +70,15 @@ export function rgb2hsv({ r, g, b }: Color["rgb"]): Color["hsv"] {
   const s = max ? (d / max) * 100 : 0;
   const v = max * 100;
 
-  return { h, s, v };
+  return { h, s, v, a };
 }
 
-export function hsv2rgb({ h, s, v }: Color["hsv"]): Color["rgb"] {
+export function hsv2rgb({ h, s, v, a }: Color["hsv"]): Color["rgb"] {
   s /= 100;
   v /= 100;
+  if (a !== undefined) {
+    a = Math.round((a / 100) * 255);
+  }
 
   const i = ~~(h / 60);
   const f = h / 60 - i;
@@ -71,11 +91,11 @@ export function hsv2rgb({ h, s, v }: Color["hsv"]): Color["rgb"] {
   const g = Math.round([t, v, v, q, p, p][index] * 255);
   const b = Math.round([p, p, t, v, v, q][index] * 255);
 
-  return { r, g, b };
+  return { r, g, b, a };
 }
 
-export function rgb2hex({ r, g, b }: Color["rgb"]): Color["hex"] {
-  const hex = [r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("");
+export function rgb2hex({ r, g, b, a }: Color["rgb"]): Color["hex"] {
+  const hex = [r, g, b, a].map((v) => (v !== undefined ? v.toString(16).padStart(2, "0") : "")).join("");
 
   return `#${hex}`;
 }

--- a/src/utils/convert.util.ts
+++ b/src/utils/convert.util.ts
@@ -44,9 +44,11 @@ export function hex2rgb(hex: Color["hex"]): Color["rgb"] {
   const r = parseInt(hex.slice(0, 2), 16);
   const g = parseInt(hex.slice(2, 4), 16);
   const b = parseInt(hex.slice(4, 6), 16);
-  const a = parseInt(hex.slice(6, 8), 16);
+  let a = parseInt(hex.slice(6, 8), 16) || undefined;
 
-  return { r, g, b, a: Number.isNaN(a) ? undefined : a / 255 };
+  if (a) a /= 255;
+
+  return { r, g, b, a };
 }
 
 export function rgb2hsv({ r, g, b, a }: Color["rgb"]): Color["hsv"] {

--- a/src/utils/coordinates.util.ts
+++ b/src/utils/coordinates.util.ts
@@ -14,3 +14,9 @@ export function getHueCoordinates(h: number, width: number): number {
 
   return x;
 }
+
+export function getAlphaCoordinates(a: number, width: number): number {
+  const x = (a / 100) * width;
+
+  return x;
+}

--- a/src/utils/coordinates.util.ts
+++ b/src/utils/coordinates.util.ts
@@ -16,7 +16,7 @@ export function getHueCoordinates(h: number, width: number): number {
 }
 
 export function getAlphaCoordinates(a: number, width: number): number {
-  const x = (a / 100) * width;
+  const x = a * width;
 
   return x;
 }

--- a/src/utils/roundFloat.util.ts
+++ b/src/utils/roundFloat.util.ts
@@ -1,0 +1,3 @@
+export function roundFloat(n: number, decimalPlaces: number): number {
+  return Math.round(n * Math.pow(10, decimalPlaces)) / Math.pow(10, decimalPlaces);
+}


### PR DESCRIPTION
### Checklist

- [x] Code is up-to-date with the `master` branch.
- [x] `yarn test (npm run test)` passes with this change.
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/Wondermarin/react-color-palette/blob/master/.github/CONTRIBUTING.md)

### Description of Change

I took a crack at adding alpha support. The only public interface changes are the addition of an optional boolean `alpha` prop to display the alpha slider and toggle parsing of alpha values from the text inputs, as well as an extension of the color constructors to accept 4/8-digit hex strings, an additional `a` property on rgb/hsv colors, and four-value arrays.

There should be no breaking changes unless a user was already passing in 4/8-digit hex strings, four-value arrays, or objects with `a` alpha channels, in which case those will now be round-tripped appropriately instead of truncated. Since that behavior would technically be a violation of the previous interface I think it's up to you how you want to handle that.

The utils are updated to handle the alpha channel if present/not `undefined`. There's a new alpha slider component below the hue slider that's only visible if the `alpha` prop is passed in. And the text inputs will correctly parse and display alpha values if they are provided. If no alpha value is set, the components return the colors without an alpha value.

Absolutely willing to go back and forth on this if it's not up to snuff for the project! I'd been looking for a TypeScript-based color picker for a while and couldn't find one quite as clean as yours.