### PR TITLE
fix: infinite useColor re-renders

### DIFF
--- a/src/hooks/useColor.hook.ts
+++ b/src/hooks/useColor.hook.ts
@@ -1,5 +1,5 @@
 import { Color } from "../interfaces/Color.interface";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { toColor } from "../utils/toColor.util";
 
 /**
@@ -24,32 +24,18 @@ export function useColor<M extends keyof Color, C extends Color[M]>(
   model: M,
   initColor: C
 ): [Color, React.Dispatch<React.SetStateAction<Color>>] {
- // Store initColor in state instead of using it directly as a useCallback dep to avoid infinite re-renders when "initColor" is an object
-  const [initColorValue] = useState(initColor);
-
-  const getColor = useCallback(() => {
-    if (model === "hex") {
-      const color = initColorValue as Color["hex"];
-
-      return toColor("hex", color);
-    } else if (model === "rgb") {
-      const color = initColorValue as Color["rgb"];
-
-      return toColor("rgb", color);
-    } else if (model === "hsv") {
-      const color = initColorValue as Color["hsv"];
-
-      return toColor("hsv", color);
+  const [color, setColor] = useState(() => {
+    switch (model) {
+      case "hex":
+        return toColor("hex", initColor as Color["hex"]);
+      case "rgb":
+        return toColor("rgb", initColor as Color["rgb"]);
+      case "hsv":
+        return toColor("hsv", initColor as Color["hsv"]);
+      default:
+        return toColor("hex", "#121212");
     }
-
-    return toColor("hex", "#000000");
-  }, [model, initColorValue]);
-
-  const [color, setColor] = useState(getColor);
-
-  useEffect(() => {
-    setColor(getColor);
-  }, [getColor]);
+  });
 
   return [color, setColor];
 }

--- a/src/hooks/useColor.hook.ts
+++ b/src/hooks/useColor.hook.ts
@@ -24,7 +24,7 @@ export function useColor<M extends keyof Color, C extends Color[M]>(
   model: M,
   initColor: C
 ): [Color, React.Dispatch<React.SetStateAction<Color>>] {
- // Store initColor in state instead of using it directly as a useEffect dep to avoid infinite re-renders when "initColor" is an object
+ // Store initColor in state instead of using it directly as a useCallback dep to avoid infinite re-renders when "initColor" is an object
   const [initColorValue] = useState(initColor);
 
   const getColor = useCallback(() => {

--- a/src/hooks/useColor.hook.ts
+++ b/src/hooks/useColor.hook.ts
@@ -24,23 +24,26 @@ export function useColor<M extends keyof Color, C extends Color[M]>(
   model: M,
   initColor: C
 ): [Color, React.Dispatch<React.SetStateAction<Color>>] {
+ // Store initColor in state instead of using it directly as a useEffect dep to avoid infinite re-renders when "initColor" is an object
+  const [initColorValue] = useState(initColor);
+
   const getColor = useCallback(() => {
     if (model === "hex") {
-      const color = initColor as Color["hex"];
+      const color = initColorValue as Color["hex"];
 
       return toColor("hex", color);
     } else if (model === "rgb") {
-      const color = initColor as Color["rgb"];
+      const color = initColorValue as Color["rgb"];
 
       return toColor("rgb", color);
     } else if (model === "hsv") {
-      const color = initColor as Color["hsv"];
+      const color = initColorValue as Color["hsv"];
 
       return toColor("hsv", color);
     }
 
     return toColor("hex", "#000000");
-  }, [model, initColor]);
+  }, [model, initColorValue]);
 
   const [color, setColor] = useState(getColor);
 


### PR DESCRIPTION
Fix infinite re-renders when using rgb or hsv as initColor argument of useColor

<!--
  Before opening the request, make sure that all the listed conditions are met.

  - Code is up-to-date with the `master` branch.
  - `yarn test (npm run test)` passes with this change.
  - The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/Wondermarin/react-color-palette/blob/master/.github/CONTRIBUTING.md)

  If your PR adds new functionality, you should also change the `demo`!
-->

### Description of Change

Should fix #25 