### PR TITLE
fix: saturation height reactivity

### DIFF
--- a/src/components/saturation/saturation.component.tsx
+++ b/src/components/saturation/saturation.component.tsx
@@ -42,7 +42,11 @@ export const Saturation = memo(({ height, color, onChange }: ISaturationProps) =
 
   return (
     <Interactive onCoordinateChange={updateColor}>
-      <div ref={setSaturationRef} style={{ height, backgroundColor: `hsl(${hsl})` }} className="rcp-saturation">
+      <div
+        ref={setSaturationRef}
+        style={{ height: `${height}px`, backgroundColor: `hsl(${hsl})` }}
+        className="rcp-saturation"
+      >
         <div
           style={{ left: position.x, top: position.y, backgroundColor: `rgb(${rgb})` }}
           className="rcp-saturation-cursor"


### PR DESCRIPTION
<!--
  Before opening the request, make sure that all the listed conditions are met.

  - Code is up-to-date with the `master` branch.
  - `yarn test (npm run test)` passes with this change.
  - The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/Wondermarin/react-color-palette/blob/master/.github/CONTRIBUTING.md)

  If your PR adds new functionality, you should also change the `demo`!
-->

### Description of Change

This is PR fixes the height reactivity in the Saturation component. Passing in a simple number for the `height` style only sets an initial value, all subsequent values will be ignored.

The fix is quite simple, pass in a valid value to the `height` style prop. In this case an interpolated string with the height and an appended `px`.

Lint + Tests pass

<!--
  A brief description of what you did and why the project needs it.
-->

<!--
  Thank you for helping the project, thanks to you it will live <3
-->
