### PR TITLE
feat: add disabled flag to color picker component

### DIFF
--- a/src/components/alpha/alpha.component.tsx
+++ b/src/components/alpha/alpha.component.tsx
@@ -9,9 +9,10 @@ import { Interactive } from "../interactive";
 interface IAlphaProps {
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly disabled: boolean;
 }
 
-export const Alpha = memo(({ color, onChange }: IAlphaProps) => {
+export const Alpha = memo(({ color, onChange, disabled }: IAlphaProps) => {
   const [alphaRef, { width }] = useBoundingClientRect<HTMLDivElement>();
 
   const position = useMemo(() => {
@@ -36,7 +37,7 @@ export const Alpha = memo(({ color, onChange }: IAlphaProps) => {
   const rgba = useMemo(() => [rgb, color.rgb.a].join(" / "), [rgb, color.rgb.a]);
 
   return (
-    <Interactive onCoordinateChange={updateColor}>
+    <Interactive onCoordinateChange={updateColor} disabled={disabled}>
       <div
         ref={alphaRef}
         style={{

--- a/src/components/color-picker/color-picker.component.tsx
+++ b/src/components/color-picker/color-picker.component.tsx
@@ -15,20 +15,21 @@ interface IColorPickerProps {
   readonly hideInput?: (keyof IColor)[] | boolean;
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly disabled?: boolean;
 }
 
 export const ColorPicker = memo(
-  ({ height = 200, hideAlpha = false, hideInput = false, color, onChange }: IColorPickerProps) => (
+  ({ height = 200, hideAlpha = false, hideInput = false, color, onChange, disabled = false }: IColorPickerProps) => (
     <div className="rcp-root rcp">
-      <Saturation height={height} color={color} onChange={onChange} />
+      <Saturation height={height} color={color} onChange={onChange} disabled={disabled} />
       <div className="rcp-body">
         <section className="rcp-section">
-          <Hue color={color} onChange={onChange} />
-          {!hideAlpha && <Alpha color={color} onChange={onChange} />}
+          <Hue color={color} onChange={onChange} disabled={disabled} />
+          {!hideAlpha && <Alpha color={color} onChange={onChange} disabled={disabled} />}
         </section>
         {(!isFieldHide(hideInput, "hex") || !isFieldHide(hideInput, "rgb") || !isFieldHide(hideInput, "hsv")) && (
           <section className="rcp-section">
-            <Fields hideInput={hideInput} color={color} onChange={onChange} />
+            <Fields hideInput={hideInput} color={color} onChange={onChange} disabled={disabled} />
           </section>
         )}
       </div>

--- a/src/components/fields/fields.component.tsx
+++ b/src/components/fields/fields.component.tsx
@@ -9,9 +9,10 @@ interface IFieldsProps {
   readonly hideInput: (keyof IColor)[] | boolean;
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly disabled: boolean;
 }
 
-export const Fields = memo(({ hideInput, color, onChange }: IFieldsProps) => {
+export const Fields = memo(({ hideInput, color, onChange, disabled }: IFieldsProps) => {
   const [fields, setFields] = useState({
     hex: {
       value: color.hex,
@@ -84,6 +85,7 @@ export const Fields = memo(({ hideInput, color, onChange }: IFieldsProps) => {
               id="hex"
               className="rcp-field-input"
               value={fields.hex.value}
+              disabled={disabled}
               onChange={onInputChange("hex")}
               onFocus={onInputFocus("hex")}
               onBlur={onInputBlur("hex")}
@@ -102,6 +104,7 @@ export const Fields = memo(({ hideInput, color, onChange }: IFieldsProps) => {
                 id="rgb"
                 className="rcp-field-input"
                 value={fields.rgb.value}
+                disabled={disabled}
                 onChange={onInputChange("rgb")}
                 onFocus={onInputFocus("rgb")}
                 onBlur={onInputBlur("rgb")}
@@ -117,6 +120,7 @@ export const Fields = memo(({ hideInput, color, onChange }: IFieldsProps) => {
                 id="hsv"
                 className="rcp-field-input"
                 value={fields.hsv.value}
+                disabled={disabled}
                 onChange={onInputChange("hsv")}
                 onFocus={onInputFocus("hsv")}
                 onBlur={onInputBlur("hsv")}

--- a/src/components/hue/hue.component.tsx
+++ b/src/components/hue/hue.component.tsx
@@ -9,9 +9,10 @@ import { Interactive } from "../interactive";
 interface IHueProps {
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly disabled: boolean;
 }
 
-export const Hue = memo(({ color, onChange }: IHueProps) => {
+export const Hue = memo(({ color, onChange, disabled }: IHueProps) => {
   const [hueRef, { width }] = useBoundingClientRect<HTMLDivElement>();
 
   const position = useMemo(() => {
@@ -35,7 +36,7 @@ export const Hue = memo(({ color, onChange }: IHueProps) => {
   const hsl = useMemo(() => [color.hsv.h, "100%", "50%"].join(" "), [color.hsv.h]);
 
   return (
-    <Interactive onCoordinateChange={updateColor}>
+    <Interactive onCoordinateChange={updateColor} disabled={disabled}>
       <div ref={hueRef} className="rcp-hue">
         <div style={{ left: position.x, backgroundColor: `hsl(${hsl})` }} className="rcp-hue-cursor" />
       </div>

--- a/src/components/interactive/interactive.component.tsx
+++ b/src/components/interactive/interactive.component.tsx
@@ -7,9 +7,10 @@ import { clamp } from "@/utils/clamp";
 interface IInteractiveProps {
   readonly onCoordinateChange: (x: number, y: number) => void;
   readonly children: React.ReactNode;
+  readonly disabled: boolean;
 }
 
-export const Interactive = memo(({ onCoordinateChange, children }: IInteractiveProps) => {
+export const Interactive = memo(({ onCoordinateChange, children, disabled }: IInteractiveProps) => {
   const [interactiveRef, { width, height }, getPosition] = useBoundingClientRect<HTMLDivElement>();
 
   const move = useCallback(
@@ -48,7 +49,12 @@ export const Interactive = memo(({ onCoordinateChange, children }: IInteractiveP
   );
 
   return (
-    <div ref={interactiveRef} className="rcp-interactive" onPointerDown={onPointerDown}>
+    <div
+      ref={interactiveRef}
+      className="rcp-interactive"
+      style={{ cursor: disabled ? "not-allowed" : "move" }}
+      onPointerDown={disabled ? undefined : onPointerDown}
+    >
       {children}
     </div>
   );

--- a/src/components/saturation/saturation.component.tsx
+++ b/src/components/saturation/saturation.component.tsx
@@ -10,9 +10,10 @@ interface ISaturationProps {
   readonly height: number;
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly disabled: boolean;
 }
 
-export const Saturation = memo(({ height, color, onChange }: ISaturationProps) => {
+export const Saturation = memo(({ height, color, onChange, disabled }: ISaturationProps) => {
   const [saturationRef, { width }] = useBoundingClientRect<HTMLDivElement>();
 
   const position = useMemo(() => {
@@ -39,7 +40,7 @@ export const Saturation = memo(({ height, color, onChange }: ISaturationProps) =
   const rgb = useMemo(() => [color.rgb.r, color.rgb.g, color.rgb.b].join(" "), [color.rgb.r, color.rgb.g, color.rgb.b]);
 
   return (
-    <Interactive onCoordinateChange={updateColor}>
+    <Interactive onCoordinateChange={updateColor} disabled={disabled}>
       <div ref={saturationRef} style={{ height, backgroundColor: `hsl(${hsl})` }} className="rcp-saturation">
         <div
           style={{ left: position.x, top: position.y, backgroundColor: `rgb(${rgb})` }}


### PR DESCRIPTION
### Description of Change

Hi, I loved the package, simple and beautiful.

As I was using it to build my own ready-to-use UI components, I missed the disabled flag as prop.

It is useful for when you don't want the user to update the existing color. I can think in those examples:

a) when the current user does not have the permission to edit;
b) when you can not change the color once it was set;

Of course, another solution for those cases would be to only display the color in a badge for example, but in the end I wanted to contribute somehow. Plus, you can check it is common to have this disabled flag (e.g.: https://primereact.org/colorpicker/)
 
That's it guys. Quick overview and PR, if you found this a good idea please test it before merge. If don't think it is a good idea, no problem at all. ;)
