### PR TITLE
feat: onChangeComplete event

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ export function App() {
     <td></td>
     <td>Сallback function will be fired when <a href="#icolor">color</a> changes.</td>
   </tr>
+  <tr>
+    <td>onChangeComplete</td>
+    <td>Function</td>
+    <td></td>
+    <td>Callback function will be fired when the interaction is complete with the color picker.</td>
+  </tr>
 </table>
 
 ### `<Saturation />`
@@ -170,6 +176,12 @@ export function App() {
     <td></td>
     <td>Сallback function will be fired when <a href="#icolor">color</a> changes.</td>
   </tr>
+  <tr>
+    <td>onChangeComplete</td>
+    <td>Function</td>
+    <td></td>
+    <td>Callback function will be fired when the interaction is complete with the saturation picker.</td>
+  </tr>
 </table>
 
 ### `<Hue />`
@@ -193,6 +205,12 @@ export function App() {
     <td></td>
     <td>Сallback function will be fired when <a href="#icolor">color</a> changes.</td>
   </tr>
+  <tr>
+    <td>onChangeComplete</td>
+    <td>Function</td>
+    <td></td>
+    <td>Callback function will be fired when the interaction is complete with the hue picker.</td>
+  </tr>
 </table>
 
 ### `<Alpha />`
@@ -215,6 +233,12 @@ export function App() {
     <td>Function</td>
     <td></td>
     <td>Сallback function will be fired when <a href="#icolor">color</a> changes.</td>
+  </tr>
+  <tr>
+    <td>onChangeComplete</td>
+    <td>Function</td>
+    <td></td>
+    <td>Callback function will be fired when the interaction is complete with the alpha picker.</td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ export function App() {
 
 ### onChangeComplete optional callback
 ```tsx
-import { ColorPicker, useColor } from "react-color-palette";
+import { ColorPicker, useColor, type IColor } from "react-color-palette";
 import "react-color-palette/css";
 
 export function App() {

--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ export function App() {
 }
 ```
 
+### onChangeComplete optional callback
+```tsx
+import { ColorPicker, useColor } from "react-color-palette";
+import "react-color-palette/css";
+
+export function App() {
+  const [color, setColor] = useColor("#123123");
+
+  const onChangeComplete = (color: IColor) => localStorage.setItem("color", color.hex);
+
+  return <ColorPicker hideInput={["rgb", "hsv"]} color={color} onChange={setColor} onChangeComplete={onChangeComplete} />
+}
+```
+
 ## API
 
 ### `<ColorPicker />`

--- a/src/components/alpha/alpha.component.tsx
+++ b/src/components/alpha/alpha.component.tsx
@@ -9,9 +9,10 @@ import { Interactive } from "../interactive";
 interface IAlphaProps {
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly onChangeComplete?: (color: IColor) => void;
 }
 
-export const Alpha = memo(({ color, onChange }: IAlphaProps) => {
+export const Alpha = memo(({ color, onChange, onChangeComplete }: IAlphaProps) => {
   const [alphaRef, { width }] = useBoundingClientRect<HTMLDivElement>();
 
   const position = useMemo(() => {
@@ -21,15 +22,16 @@ export const Alpha = memo(({ color, onChange }: IAlphaProps) => {
   }, [color.hsv.a, width]);
 
   const updateColor = useCallback(
-    (x: number) => {
+    (x: number, _y: number, final?: boolean) => {
       const nextColor = ColorService.convert("hsv", {
         ...color.hsv,
         a: x / width,
       });
 
       onChange(nextColor);
+      if (final) onChangeComplete?.(nextColor);
     },
-    [color.hsv, width, onChange]
+    [color.hsv, width, onChange, onChangeComplete]
   );
 
   const rgb = useMemo(() => [color.rgb.r, color.rgb.g, color.rgb.b].join(" "), [color.rgb.r, color.rgb.g, color.rgb.b]);

--- a/src/components/alpha/alpha.component.tsx
+++ b/src/components/alpha/alpha.component.tsx
@@ -22,7 +22,7 @@ export const Alpha = memo(({ color, onChange, onChangeComplete }: IAlphaProps) =
   }, [color.hsv.a, width]);
 
   const updateColor = useCallback(
-    (x: number, _y: number, final?: boolean) => {
+    (final: boolean, x: number) => {
       const nextColor = ColorService.convert("hsv", {
         ...color.hsv,
         a: x / width,

--- a/src/components/color-picker/color-picker.component.tsx
+++ b/src/components/color-picker/color-picker.component.tsx
@@ -24,12 +24,12 @@ export const ColorPicker = memo(
       <Saturation height={height} color={color} onChange={onChange} onChangeComplete={onChangeComplete} />
       <div className="rcp-body">
         <section className="rcp-section">
-          <Hue color={color} onChange={onChange} />
+          <Hue color={color} onChange={onChange} onChangeComplete={onChangeComplete} />
           {!hideAlpha && <Alpha color={color} onChange={onChange} onChangeComplete={onChangeComplete} />}
         </section>
         {(!isFieldHide(hideInput, "hex") || !isFieldHide(hideInput, "rgb") || !isFieldHide(hideInput, "hsv")) && (
           <section className="rcp-section">
-            <Fields hideInput={hideInput} color={color} onChange={onChange} />
+            <Fields hideInput={hideInput} color={color} onChange={onChange} onChangeComplete={onChangeComplete} />
           </section>
         )}
       </div>

--- a/src/components/color-picker/color-picker.component.tsx
+++ b/src/components/color-picker/color-picker.component.tsx
@@ -15,16 +15,17 @@ interface IColorPickerProps {
   readonly hideInput?: (keyof IColor)[] | boolean;
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly onChangeComplete?: (color: IColor) => void;
 }
 
 export const ColorPicker = memo(
-  ({ height = 200, hideAlpha = false, hideInput = false, color, onChange }: IColorPickerProps) => (
+  ({ height = 200, hideAlpha = false, hideInput = false, color, onChange, onChangeComplete }: IColorPickerProps) => (
     <div className="rcp-root rcp">
-      <Saturation height={height} color={color} onChange={onChange} />
+      <Saturation height={height} color={color} onChange={onChange} onChangeComplete={onChangeComplete} />
       <div className="rcp-body">
         <section className="rcp-section">
           <Hue color={color} onChange={onChange} />
-          {!hideAlpha && <Alpha color={color} onChange={onChange} />}
+          {!hideAlpha && <Alpha color={color} onChange={onChange} onChangeComplete={onChangeComplete} />}
         </section>
         {(!isFieldHide(hideInput, "hex") || !isFieldHide(hideInput, "rgb") || !isFieldHide(hideInput, "hsv")) && (
           <section className="rcp-section">

--- a/src/components/fields/fields.component.tsx
+++ b/src/components/fields/fields.component.tsx
@@ -9,9 +9,10 @@ interface IFieldsProps {
   readonly hideInput: (keyof IColor)[] | boolean;
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly onChangeComplete?: (color: IColor) => void;
 }
 
-export const Fields = memo(({ hideInput, color, onChange }: IFieldsProps) => {
+export const Fields = memo(({ hideInput, color, onChange, onChangeComplete }: IFieldsProps) => {
   const [fields, setFields] = useState({
     hex: {
       value: color.hex,
@@ -69,10 +70,16 @@ export const Fields = memo(({ hideInput, color, onChange }: IFieldsProps) => {
 
   const onInputBlur = useCallback(
     <T extends keyof typeof fields>(field: T) =>
-      () => {
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        const { value } = event.target;
+
         setFields((fields) => ({ ...fields, [field]: { ...fields[field], inputted: false } }));
+
+        if (field === "hsv") onChangeComplete?.(ColorService.convert("hsv", ColorService.toHsv(value)));
+        else if (field === "rgb") onChangeComplete?.(ColorService.convert("rgb", ColorService.toRgb(value)));
+        else onChangeComplete?.(ColorService.convert("hex", value));
       },
-    []
+    [onChangeComplete]
   );
 
   return (

--- a/src/components/hue/hue.component.tsx
+++ b/src/components/hue/hue.component.tsx
@@ -9,9 +9,10 @@ import { Interactive } from "../interactive";
 interface IHueProps {
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly onChangeComplete?: (color: IColor) => void;
 }
 
-export const Hue = memo(({ color, onChange }: IHueProps) => {
+export const Hue = memo(({ color, onChange, onChangeComplete }: IHueProps) => {
   const [hueRef, { width }] = useBoundingClientRect<HTMLDivElement>();
 
   const position = useMemo(() => {
@@ -21,15 +22,16 @@ export const Hue = memo(({ color, onChange }: IHueProps) => {
   }, [color.hsv.h, width]);
 
   const updateColor = useCallback(
-    (x: number) => {
+    (x: number, _y: number, final?: boolean) => {
       const nextColor = ColorService.convert("hsv", {
         ...color.hsv,
         h: (x / width) * 360,
       });
 
       onChange(nextColor);
+      if (final) onChangeComplete?.(nextColor);
     },
-    [color.hsv, width, onChange]
+    [color.hsv, width, onChange, onChangeComplete]
   );
 
   const hsl = useMemo(() => [color.hsv.h, "100%", "50%"].join(" "), [color.hsv.h]);

--- a/src/components/hue/hue.component.tsx
+++ b/src/components/hue/hue.component.tsx
@@ -22,7 +22,7 @@ export const Hue = memo(({ color, onChange, onChangeComplete }: IHueProps) => {
   }, [color.hsv.h, width]);
 
   const updateColor = useCallback(
-    (x: number, _y: number, final?: boolean) => {
+    (final: boolean, x: number) => {
       const nextColor = ColorService.convert("hsv", {
         ...color.hsv,
         h: (x / width) * 360,

--- a/src/components/interactive/interactive.component.tsx
+++ b/src/components/interactive/interactive.component.tsx
@@ -5,7 +5,7 @@ import { useBoundingClientRect } from "@/hooks/use-bounding-client-rect";
 import { clamp } from "@/utils/clamp";
 
 interface IInteractiveProps {
-  readonly onCoordinateChange: (x: number, y: number, final?: boolean) => void;
+  readonly onCoordinateChange: (final: boolean, x: number, y: number) => void;
   readonly children: React.ReactNode;
 }
 
@@ -19,7 +19,7 @@ export const Interactive = memo(({ onCoordinateChange, children }: IInteractiveP
       const x = clamp(event.clientX - left, 0, width);
       const y = clamp(event.clientY - top, 0, height);
 
-      onCoordinateChange(x, y, final);
+      onCoordinateChange(final, x, y);
     },
     [width, height, getPosition, onCoordinateChange]
   );

--- a/src/components/interactive/interactive.component.tsx
+++ b/src/components/interactive/interactive.component.tsx
@@ -5,7 +5,7 @@ import { useBoundingClientRect } from "@/hooks/use-bounding-client-rect";
 import { clamp } from "@/utils/clamp";
 
 interface IInteractiveProps {
-  readonly onCoordinateChange: (x: number, y: number) => void;
+  readonly onCoordinateChange: (x: number, y: number, final?: boolean) => void;
   readonly children: React.ReactNode;
 }
 
@@ -13,13 +13,13 @@ export const Interactive = memo(({ onCoordinateChange, children }: IInteractiveP
   const [interactiveRef, { width, height }, getPosition] = useBoundingClientRect<HTMLDivElement>();
 
   const move = useCallback(
-    (event: React.PointerEvent<HTMLDivElement> | PointerEvent) => {
+    (event: React.PointerEvent<HTMLDivElement> | PointerEvent, final = false) => {
       const { left, top } = getPosition();
 
       const x = clamp(event.clientX - left, 0, width);
       const y = clamp(event.clientY - top, 0, height);
 
-      onCoordinateChange(x, y);
+      onCoordinateChange(x, y, final);
     },
     [width, height, getPosition, onCoordinateChange]
   );
@@ -35,7 +35,7 @@ export const Interactive = memo(({ onCoordinateChange, children }: IInteractiveP
       };
 
       const onPointerUp = (event: PointerEvent) => {
-        move(event);
+        move(event, true);
 
         document.removeEventListener("pointermove", onPointerMove, false);
         document.removeEventListener("pointerup", onPointerUp, false);

--- a/src/components/saturation/saturation.component.tsx
+++ b/src/components/saturation/saturation.component.tsx
@@ -10,9 +10,10 @@ interface ISaturationProps {
   readonly height: number;
   readonly color: IColor;
   readonly onChange: (color: IColor) => void;
+  readonly onChangeComplete?: (color: IColor) => void;
 }
 
-export const Saturation = memo(({ height, color, onChange }: ISaturationProps) => {
+export const Saturation = memo(({ height, color, onChange, onChangeComplete }: ISaturationProps) => {
   const [saturationRef, { width }] = useBoundingClientRect<HTMLDivElement>();
 
   const position = useMemo(() => {
@@ -23,7 +24,7 @@ export const Saturation = memo(({ height, color, onChange }: ISaturationProps) =
   }, [color.hsv.s, color.hsv.v, width, height]);
 
   const updateColor = useCallback(
-    (x: number, y: number) => {
+    (x: number, y: number, final?: boolean) => {
       const nextColor = ColorService.convert("hsv", {
         ...color.hsv,
         s: (x / width) * 100,
@@ -31,8 +32,9 @@ export const Saturation = memo(({ height, color, onChange }: ISaturationProps) =
       });
 
       onChange(nextColor);
+      if (final) onChangeComplete?.(nextColor);
     },
-    [color.hsv, width, height, onChange]
+    [color.hsv, width, height, onChange, onChangeComplete]
   );
 
   const hsl = useMemo(() => [color.hsv.h, "100%", "50%"].join(" "), [color.hsv.h]);

--- a/src/components/saturation/saturation.component.tsx
+++ b/src/components/saturation/saturation.component.tsx
@@ -24,7 +24,7 @@ export const Saturation = memo(({ height, color, onChange, onChangeComplete }: I
   }, [color.hsv.s, color.hsv.v, width, height]);
 
   const updateColor = useCallback(
-    (x: number, y: number, final?: boolean) => {
+    (final: boolean, x: number, y: number) => {
       const nextColor = ColorService.convert("hsv", {
         ...color.hsv,
         s: (x / width) * 100,


### PR DESCRIPTION
<!--
  Before opening the request, make sure that all the listed conditions are met.

  - Code is up-to-date with the `master` branch.
  - `yarn test (npm run test)` passes with this change.
  - The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/Wondermarin/react-color-palette/blob/master/.github/CONTRIBUTING.md)

  If your PR adds new functionality, you should also change the `demo`!
-->

Hi! This is a very good library and it is a breeze to integrate it.

I've wanted to enhance it by adding a new optional event called `onChangeComplete` that its goal to be fired right after the user _stops_ interacting with any element, which is useful for the ones that needs to perform a side-effect action when that happens.

Use case example: You want to save the user's chosen color either remotely thru an API or locally in the storage. By hooking up this action on `onChange`, you will have a lot of actions happening as the user might be _exploring_ the color picker up until the point it stops the interaction. 

### Description of Change

A new prop is added to Interactive component and therefore propagated into Alpha, Saturation and Hue ones. I've also added the change into Fields by leveraging the onBlur input event.

In Interactive component I've chosen to modify the original `move` event by adding a boolean at the end by I'm not completely sure that is the best option to achieve the goal. Happy to apply any modifications you may see necessary.

Finally, added the README.md changes: one new example using the new event and add a new entry to the prop table.
<!--
  A brief description of what you did and why the project needs it.
-->

<!--
  Thank you for helping the project, thanks to you it will live <3
-->
