### PR TITLE
fix: useBoundingClientRect wrong dimensions in modal (#67)

### DIFF
--- a/src/hooks/use-bounding-client-rect/use-bounding-client-rect.hook.ts
+++ b/src/hooks/use-bounding-client-rect/use-bounding-client-rect.hook.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 interface ISize {
   readonly width: number;
@@ -12,32 +12,43 @@ interface IPosition {
   readonly bottom: number;
 }
 
+const getElementDimensions = (element: Element): ISize => {
+  const rect = element.getBoundingClientRect();
+
+  return {
+    width: rect.width,
+    height: rect.height,
+  };
+};
+
 export function useBoundingClientRect<T extends HTMLElement>(): [React.RefObject<T>, ISize, () => IPosition] {
   const ref = useRef<T>(null);
 
-  const [resizeCounter, setResizeCounter] = useState(0);
-
-  const onResize = useCallback(() => setResizeCounter((resizeCounter) => resizeCounter + 1), []);
+  const [size, setSize] = useState<ISize>({ width: 1, height: 1 });
 
   useLayoutEffect(() => {
-    window.addEventListener("resize", onResize, false);
+    const onWindowResize = () => {
+      if (!ref.current) return;
+      setSize(getElementDimensions(ref.current));
+    };
+    const onElementResize: ResizeObserverCallback = ([{ contentBoxSize }]) => {
+      setSize({
+        height: contentBoxSize[0].blockSize,
+        width: contentBoxSize[0].inlineSize,
+      });
+    };
 
-    const observer = new ResizeObserver(onResize);
+    window.addEventListener("resize", onWindowResize, false);
+
+    const observer = new ResizeObserver(onElementResize);
 
     if (ref.current) observer.observe(ref.current);
 
     return () => {
-      window.removeEventListener("resize", onResize, false);
+      window.removeEventListener("resize", onWindowResize, false);
       observer.disconnect();
     };
-  }, [onResize]);
-
-  const size = useMemo(() => {
-    const { width = 1, height = 1 } = ref.current?.getBoundingClientRect() ?? ({} as DOMRect);
-
-    return { width, height };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resizeCounter]);
+  }, []);
 
   const getPosition = useCallback(() => {
     const { left = 1, right = 1, top = 1, bottom = 1 } = ref.current?.getBoundingClientRect() ?? ({} as DOMRect);


### PR DESCRIPTION
fix: useBoundingClientRect wrong dimensions in modal + removed  resizeCounter state (#67)

### Description of Change

in useBoundingClientRect: separated functions passed to ResizeObserver and to window.addEventListener.
(not quite sure why but accessing element ref inside of ResizeObserverCallback returns wrong dimensions in the modal) 

Also removed resizeCounter and changes size = useMemo to [size,] = useState(). Initially I assumed that was causing the issue. Unless there was a reason to use resizeCounter+ size=useMemo, I don't see any issues with it + it will reduce extra render


