### PR TITLE
feat: Add disabled prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ export function App() {
     <td>disabled</td>
     <td>boolean</td>
     <td>false</td>
-    <td>Disables editing.</td>
+    <td>Disables interactivity.</td>
   </tr>
   <tr>
     <td>onChange</td>
@@ -194,7 +194,7 @@ export function App() {
     <td>disabled</td>
     <td>boolean</td>
     <td>false</td>
-    <td>Disables editing.</td>
+    <td>Disables interactivity.</td>
   </tr>
   <tr>
     <td>onChange</td>
@@ -229,7 +229,7 @@ export function App() {
     <td>disabled</td>
     <td>boolean</td>
     <td>false</td>
-    <td>Disables editing.</td>
+    <td>Disables interactivity.</td>
   </tr>
   <tr>
     <td>onChange</td>
@@ -264,7 +264,7 @@ export function App() {
     <td>disabled</td>
     <td>boolean</td>
     <td>false</td>
-    <td>Disables editing.</td>
+    <td>Disables interactivity.</td>
   </tr>
   <tr>
     <td>onChange</td>

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ export function App() {
     <td>Current <a href="#icolor">color</a>.</td>
   </tr>
   <tr>
+    <td>disabled</td>
+    <td>boolean</td>
+    <td>false</td>
+    <td>Disables editing.</td>
+  </tr>
+  <tr>
     <td>onChange</td>
     <td>Function</td>
     <td></td>
@@ -185,6 +191,12 @@ export function App() {
     <td>Current <a href="#icolor">color</a>.</td>
   </tr>
   <tr>
+    <td>disabled</td>
+    <td>boolean</td>
+    <td>false</td>
+    <td>Disables editing.</td>
+  </tr>
+  <tr>
     <td>onChange</td>
     <td>Function</td>
     <td></td>
@@ -214,6 +226,12 @@ export function App() {
     <td>Current <a href="#icolor">color</a>.</td>
   </tr>
   <tr>
+    <td>disabled</td>
+    <td>boolean</td>
+    <td>false</td>
+    <td>Disables editing.</td>
+  </tr>
+  <tr>
     <td>onChange</td>
     <td>Function</td>
     <td></td>
@@ -241,6 +259,12 @@ export function App() {
     <td><a href="#icolor">IColor</a></td>
     <td></td>
     <td>Current <a href="#icolor">color</a>.</td>
+  </tr>
+  <tr>
+    <td>disabled</td>
+    <td>boolean</td>
+    <td>false</td>
+    <td>Disables editing.</td>
   </tr>
   <tr>
     <td>onChange</td>

--- a/src/components/alpha/alpha.component.tsx
+++ b/src/components/alpha/alpha.component.tsx
@@ -8,11 +8,12 @@ import { Interactive } from "../interactive";
 
 interface IAlphaProps {
   readonly color: IColor;
+  readonly disabled?: boolean;
   readonly onChange: (color: IColor) => void;
   readonly onChangeComplete?: (color: IColor) => void;
 }
 
-export const Alpha = memo(({ color, onChange, onChangeComplete }: IAlphaProps) => {
+export const Alpha = memo(({ color, disabled, onChange, onChangeComplete }: IAlphaProps) => {
   const [alphaRef, { width }] = useBoundingClientRect<HTMLDivElement>();
 
   const position = useMemo(() => {
@@ -38,7 +39,7 @@ export const Alpha = memo(({ color, onChange, onChangeComplete }: IAlphaProps) =
   const rgba = useMemo(() => [rgb, color.rgb.a].join(" / "), [rgb, color.rgb.a]);
 
   return (
-    <Interactive onCoordinateChange={updateColor}>
+    <Interactive disabled={disabled} onCoordinateChange={updateColor}>
       <div
         ref={alphaRef}
         style={{

--- a/src/components/color-picker/color-picker.component.tsx
+++ b/src/components/color-picker/color-picker.component.tsx
@@ -14,22 +14,45 @@ interface IColorPickerProps {
   readonly hideAlpha?: boolean;
   readonly hideInput?: (keyof IColor)[] | boolean;
   readonly color: IColor;
+  readonly disabled?: boolean;
   readonly onChange: (color: IColor) => void;
   readonly onChangeComplete?: (color: IColor) => void;
 }
 
 export const ColorPicker = memo(
-  ({ height = 200, hideAlpha = false, hideInput = false, color, onChange, onChangeComplete }: IColorPickerProps) => (
+  ({
+    height = 200,
+    hideAlpha = false,
+    hideInput = false,
+    color,
+    disabled = false,
+    onChange,
+    onChangeComplete,
+  }: IColorPickerProps) => (
     <div className="rcp-root rcp">
-      <Saturation height={height} color={color} onChange={onChange} onChangeComplete={onChangeComplete} />
+      <Saturation
+        height={height}
+        color={color}
+        disabled={disabled}
+        onChange={onChange}
+        onChangeComplete={onChangeComplete}
+      />
       <div className="rcp-body">
         <section className="rcp-section">
-          <Hue color={color} onChange={onChange} onChangeComplete={onChangeComplete} />
-          {!hideAlpha && <Alpha color={color} onChange={onChange} onChangeComplete={onChangeComplete} />}
+          <Hue color={color} disabled={disabled} onChange={onChange} onChangeComplete={onChangeComplete} />
+          {!hideAlpha && (
+            <Alpha color={color} disabled={disabled} onChange={onChange} onChangeComplete={onChangeComplete} />
+          )}
         </section>
         {(!isFieldHide(hideInput, "hex") || !isFieldHide(hideInput, "rgb") || !isFieldHide(hideInput, "hsv")) && (
           <section className="rcp-section">
-            <Fields hideInput={hideInput} color={color} onChange={onChange} onChangeComplete={onChangeComplete} />
+            <Fields
+              hideInput={hideInput}
+              color={color}
+              disabled={disabled}
+              onChange={onChange}
+              onChangeComplete={onChangeComplete}
+            />
           </section>
         )}
       </div>

--- a/src/components/fields/fields.component.tsx
+++ b/src/components/fields/fields.component.tsx
@@ -8,11 +8,12 @@ import { isFieldHide } from "@/utils/is-field-hide";
 interface IFieldsProps {
   readonly hideInput: (keyof IColor)[] | boolean;
   readonly color: IColor;
+  readonly disabled?: boolean;
   readonly onChange: (color: IColor) => void;
   readonly onChangeComplete?: (color: IColor) => void;
 }
 
-export const Fields = memo(({ hideInput, color, onChange, onChangeComplete }: IFieldsProps) => {
+export const Fields = memo(({ hideInput, color, disabled, onChange, onChangeComplete }: IFieldsProps) => {
   const [fields, setFields] = useState({
     hex: {
       value: color.hex,
@@ -90,6 +91,7 @@ export const Fields = memo(({ hideInput, color, onChange, onChangeComplete }: IF
             <input
               id="hex"
               className="rcp-field-input"
+              readOnly={disabled}
               value={fields.hex.value}
               onChange={onInputChange("hex")}
               onFocus={onInputFocus("hex")}
@@ -108,6 +110,7 @@ export const Fields = memo(({ hideInput, color, onChange, onChangeComplete }: IF
               <input
                 id="rgb"
                 className="rcp-field-input"
+                readOnly={disabled}
                 value={fields.rgb.value}
                 onChange={onInputChange("rgb")}
                 onFocus={onInputFocus("rgb")}
@@ -123,6 +126,7 @@ export const Fields = memo(({ hideInput, color, onChange, onChangeComplete }: IF
               <input
                 id="hsv"
                 className="rcp-field-input"
+                readOnly={disabled}
                 value={fields.hsv.value}
                 onChange={onInputChange("hsv")}
                 onFocus={onInputFocus("hsv")}

--- a/src/components/hue/hue.component.tsx
+++ b/src/components/hue/hue.component.tsx
@@ -8,11 +8,12 @@ import { Interactive } from "../interactive";
 
 interface IHueProps {
   readonly color: IColor;
+  readonly disabled?: boolean;
   readonly onChange: (color: IColor) => void;
   readonly onChangeComplete?: (color: IColor) => void;
 }
 
-export const Hue = memo(({ color, onChange, onChangeComplete }: IHueProps) => {
+export const Hue = memo(({ color, disabled, onChange, onChangeComplete }: IHueProps) => {
   const [hueRef, { width }] = useBoundingClientRect<HTMLDivElement>();
 
   const position = useMemo(() => {
@@ -37,7 +38,7 @@ export const Hue = memo(({ color, onChange, onChangeComplete }: IHueProps) => {
   const hsl = useMemo(() => [color.hsv.h, "100%", "50%"].join(" "), [color.hsv.h]);
 
   return (
-    <Interactive onCoordinateChange={updateColor}>
+    <Interactive disabled={disabled} onCoordinateChange={updateColor}>
       <div ref={hueRef} className="rcp-hue">
         <div style={{ left: position.x, backgroundColor: `hsl(${hsl})` }} className="rcp-hue-cursor" />
       </div>

--- a/src/components/interactive/interactive.component.tsx
+++ b/src/components/interactive/interactive.component.tsx
@@ -58,7 +58,7 @@ export const Interactive = memo(({ onCoordinateChange, children, disabled }: IIn
       className="rcp-interactive"
       onMouseDown={onStart}
       onTouchStart={onStart}
-      aria-readonly={disabled}
+      aria-disabled={disabled}
     >
       {children}
     </div>

--- a/src/components/interactive/interactive.component.tsx
+++ b/src/components/interactive/interactive.component.tsx
@@ -8,12 +8,13 @@ import { isTouch } from "@/utils/is-touch";
 interface IInteractiveProps {
   readonly onCoordinateChange: (final: boolean, x: number, y: number) => void;
   readonly children: React.ReactNode;
+  readonly disabled?: boolean;
 }
 
 type TInteractionEvent = React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement> | MouseEvent | TouchEvent;
 type TMoveEvent = React.MouseEvent<HTMLDivElement> | React.Touch | MouseEvent | Touch;
 
-export const Interactive = memo(({ onCoordinateChange, children }: IInteractiveProps) => {
+export const Interactive = memo(({ onCoordinateChange, children, disabled }: IInteractiveProps) => {
   const [interactiveRef, { width, height }, getPosition] = useBoundingClientRect<HTMLDivElement>();
 
   const move = useCallback(
@@ -52,7 +53,13 @@ export const Interactive = memo(({ onCoordinateChange, children }: IInteractiveP
   );
 
   return (
-    <div ref={interactiveRef} className="rcp-interactive" onMouseDown={onStart} onTouchStart={onStart}>
+    <div
+      ref={interactiveRef}
+      className="rcp-interactive"
+      onMouseDown={onStart}
+      onTouchStart={onStart}
+      aria-readonly={disabled}
+    >
       {children}
     </div>
   );

--- a/src/components/saturation/saturation.component.tsx
+++ b/src/components/saturation/saturation.component.tsx
@@ -9,11 +9,12 @@ import { Interactive } from "../interactive";
 interface ISaturationProps {
   readonly height: number;
   readonly color: IColor;
+  readonly disabled?: boolean;
   readonly onChange: (color: IColor) => void;
   readonly onChangeComplete?: (color: IColor) => void;
 }
 
-export const Saturation = memo(({ height, color, onChange, onChangeComplete }: ISaturationProps) => {
+export const Saturation = memo(({ height, color, disabled, onChange, onChangeComplete }: ISaturationProps) => {
   const [saturationRef, { width }] = useBoundingClientRect<HTMLDivElement>();
 
   const position = useMemo(() => {
@@ -41,7 +42,7 @@ export const Saturation = memo(({ height, color, onChange, onChangeComplete }: I
   const rgb = useMemo(() => [color.rgb.r, color.rgb.g, color.rgb.b].join(" "), [color.rgb.r, color.rgb.g, color.rgb.b]);
 
   return (
-    <Interactive onCoordinateChange={updateColor}>
+    <Interactive disabled={disabled} onCoordinateChange={updateColor}>
       <div ref={saturationRef} style={{ height, backgroundColor: `hsl(${hsl})` }} className="rcp-saturation">
         <div
           style={{ left: position.x, top: position.y, backgroundColor: `rgb(${rgb})` }}

--- a/src/css/rcp.css
+++ b/src/css/rcp.css
@@ -132,7 +132,7 @@
   padding: 5px 0;
 }
 
-.rcp-field-input[readonly] {
+.rcp-field-input:read-only {
   opacity: 0.8;
 }
 

--- a/src/css/rcp.css
+++ b/src/css/rcp.css
@@ -32,6 +32,11 @@
   touch-action: none;
 }
 
+.rcp-interactive[aria-readonly="true"] {
+  cursor: unset;
+  pointer-events: none;
+}
+
 .rcp-saturation {
   cursor: all-scroll;
   width: 100%;
@@ -125,6 +130,10 @@
   border-radius: 5px;
   outline: none;
   padding: 5px 0;
+}
+
+.rcp-field-input[readonly] {
+  opacity: 0.8;
 }
 
 .rcp-field-label {

--- a/src/css/rcp.css
+++ b/src/css/rcp.css
@@ -32,7 +32,7 @@
   touch-action: none;
 }
 
-.rcp-interactive[aria-readonly="true"] {
+.rcp-interactive[aria-disabled="true"] {
   cursor: unset;
   pointer-events: none;
 }


### PR DESCRIPTION
<!--
  Before opening the request, make sure that all the listed conditions are met.

  - Code is up-to-date with the `main` branch.
  - `pnpm test (npm run test)` passes with this change.
  - The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/Wondermarin/react-color-palette/blob/master/.github/CONTRIBUTING.md)

  If your PR adds new functionality, you should also change the `demo`!
-->

### Description of Change

Allow to show color values in a read-only/editing disabled mode.

See https://github.com/Wondermarin/react-color-palette/pull/72#issuecomment-2339512062

* I used the `readonly` attribute for inputs b/c I think it is appropriate. I remember some browsers don't allow copying from `disabled` inputs.
* Not sure if the dimmed appearance of the read-only inputs is needed (https://github.com/Wondermarin/react-color-palette/pull/72#discussion_r1632353691). Chrome by default uses the same color for r/o and r/w inputs.
* For non-inputs I used `aria-readonly` instead of `disabled` (https://github.com/Wondermarin/react-color-palette/pull/72#discussion_r1632353478), b/c `disabled` is not standard for `div`.