### PR TITLE
feat: setColor can accepts partial IColor

### DIFF
--- a/src/hooks/use-color/use-color.hook.ts
+++ b/src/hooks/use-color/use-color.hook.ts
@@ -1,13 +1,25 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { ColorService, type IColor } from "@/services/color";
 
-export function useColor(initialColor: string): [IColor, React.Dispatch<React.SetStateAction<IColor>>] {
+type TSetPartialStateAction<T> = Partial<T> | ((prevState: T) => Partial<T>);
+
+export function useColor(initialColor: string): [IColor, React.Dispatch<TSetPartialStateAction<IColor>>] {
   const [color, setColor] = useState(ColorService.convert("hex", initialColor));
+
+  const dispatchColor = useCallback((valueOrFunc: Partial<IColor> | ((color: IColor) => Partial<IColor>)) => {
+    if (typeof valueOrFunc === "function") {
+      setColor((p) => {
+        return ColorService.convertIfNeeded(valueOrFunc(p));
+      });
+    } else {
+      setColor(ColorService.convertIfNeeded(valueOrFunc));
+    }
+  }, []);
 
   useEffect(() => {
     setColor(ColorService.convert("hex", initialColor));
   }, [initialColor]);
 
-  return [color, setColor];
+  return [color, dispatchColor];
 }

--- a/src/services/color/color.service.ts
+++ b/src/services/color/color.service.ts
@@ -55,6 +55,22 @@ class ColorServiceStatic {
     return { hex, rgb, hsv };
   }
 
+  public convertIfNeeded(color: Partial<IColor>): IColor {
+    if (color.hex == null || color.rgb == null || color.hsv == null) {
+      if (color.hex) {
+        return this.convert("hex", color.hex);
+      } else if (color.rgb) {
+        return this.convert("rgb", color.rgb);
+      } else if (color.hsv) {
+        return this.convert("hsv", color.hsv);
+      }
+
+      return this.convert("hex", "#000000");
+    }
+
+    return color as IColor;
+  }
+
   public toHex(value: string): IColor["hex"] {
     if (!value.startsWith("#")) {
       const ctx = document.createElement("canvas").getContext("2d");


### PR DESCRIPTION
<!--
  Before opening the request, make sure that all the listed conditions are met.

  - Code is up-to-date with the `main` branch.
  - `pnpm test (npm run test)` passes with this change.
  - The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/Wondermarin/react-color-palette/blob/master/.github/CONTRIBUTING.md)

  If your PR adds new functionality, you should also change the `demo`!
-->

### Description of Change

<!--
  A brief description of what you did and why the project needs it.
-->

<!--
  Thank you for helping the project, thanks to you it will live <3
-->

I know we can import `ColorService` and use `convert` function before `setColor`, but I thought it would be much more convenient and useful if `setColor` could accept partial of `IColor`.  (#76)
